### PR TITLE
LIBFCREPO-265. Changed log message displaying PEM-encoded cert from info to debug.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>edu.umd.lib</groupId>
   <artifactId>header-to-cert-valve</artifactId>
-  <version>2.0.0-SNAPSHOT</version>
+  <version>1.0.1-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>header-to-cert-valve</name>

--- a/src/main/java/edu/umd/lib/tomcat/valves/HeaderToCert.java
+++ b/src/main/java/edu/umd/lib/tomcat/valves/HeaderToCert.java
@@ -80,7 +80,7 @@ public class HeaderToCert extends ValveBase implements Lifecycle {
     String pemCert = httpRequest.getHeader(headerName);
     if (pemCert != null && !pemCert.isEmpty() && !pemCert.equals("(null)")) {
       pemCert = pemCert.replaceAll(" ", "\n").replaceAll("\nCERTIFICATE", " CERTIFICATE");
-      log.info("Client cert:\n" + pemCert);
+      log.debug("Client cert:\n" + pemCert);
 
       ByteArrayInputStream in = new ByteArrayInputStream(pemCert.getBytes());
 


### PR DESCRIPTION
Intended to reduce some of the noise filling up the Tomcat logs.

https://issues.umd.edu/browse/LIBFCREPO-265